### PR TITLE
feat(04-02): Add TCP Client example

### DIFF
--- a/book-src/04-01-tcp-server.md
+++ b/book-src/04-01-tcp-server.md
@@ -38,3 +38,5 @@ When start starts up, try test like this:
 ```bash
 echo "hello zig" | nc localhost <port>
 ```
+
+The next section will show how to connect this server using Zig code.

--- a/book-src/04-02-tcp-client.md
+++ b/book-src/04-02-tcp-client.md
@@ -1,0 +1,35 @@
+## TCP Client
+
+In this example, we demonstrate how to create a TCP client to connect to the server from the previous section.
+You can run it using `zig build run 04-02 -- <port>`.
+
+```zig
+const std = @import("std");
+const net = std.net;
+const print = std.debug.print;
+
+pub fn main() !void {
+    var args = std.process.args();
+    // The First (0 index) Argument is the path to the program.
+    _ = args.skip();
+    const port_value = args.next() orelse {
+        print("expect port as command line argument\n", .{});
+        std.os.exit(1);
+    };
+    const port = try std.fmt.parseInt(u16, port_value, 10);
+
+    const peer = try net.Address.parseIp4("127.0.0.1", port);
+    // Connect to peer
+    const stream = try net.tcpConnectToAddress(peer);
+    defer stream.close();
+    print("Connecting to {}\n", .{peer});
+
+    // Sending data to peer
+    const data = "hello zig";
+    var writer = stream.writer();
+    const size = try writer.write(data);
+    print("Sending '{s}' to peer, total written: {d} bytes\n", .{ data, size });
+    // Or just using `stream.writeAll`
+    // try stream.writeAll("hello zig");
+}
+```

--- a/book-src/04-02-tcp-client.md
+++ b/book-src/04-02-tcp-client.md
@@ -10,7 +10,7 @@ const print = std.debug.print;
 
 pub fn main() !void {
     var args = std.process.args();
-    // The First (0 index) Argument is the path to the program.
+    // The first (0 index) Argument is the path to the program.
     _ = args.skip();
     const port_value = args.next() orelse {
         print("expect port as command line argument\n", .{});

--- a/book-src/04-02-tcp-client.md
+++ b/book-src/04-02-tcp-client.md
@@ -1,7 +1,7 @@
 ## TCP Client
 
 In this example, we demonstrate how to create a TCP client to connect to the server from the previous section.
-You can run it using `zig build run 04-02 -- <port>`.
+You can run it using `zig build run-04-02 -- <port>`.
 
 ```zig
 const std = @import("std");

--- a/book-src/SUMMARY.md
+++ b/book-src/SUMMARY.md
@@ -16,6 +16,7 @@
 
 - [Network]()
   - [Listen on unused port TCP/IP](./04-01-tcp-server.md)
+  - [TCP Client](./04-02-tcp-client.md)
 
 - [Web Programming]()
   - [Make HTTP requests](./05-01-http-requests.md)

--- a/build.zig
+++ b/build.zig
@@ -57,7 +57,8 @@ fn addExample(b: *std.Build, run_all: *std.build.Step) !void {
                 )).dependOn(run_step);
 
                 // 04-01 start tcp server, and won't stop so we skip it here
-                if (std.mem.eql(u8, "04-01", name)) {
+                // 04-02 is the server's client.
+                if (std.mem.eql(u8, "04-01", name) or std.mem.eql(u8, "04-02", name)) {
                     continue;
                 }
                 run_all.dependOn(run_step);

--- a/src/04-02.zig
+++ b/src/04-02.zig
@@ -4,7 +4,7 @@ const print = std.debug.print;
 
 pub fn main() !void {
     var args = std.process.args();
-    // The First (0 index) Argument is the path to the program.
+    // The first (0 index) Argument is the path to the program.
     _ = args.skip();
     const port_value = args.next() orelse {
         print("expect port as command line argument\n", .{});

--- a/src/04-02.zig
+++ b/src/04-02.zig
@@ -1,0 +1,28 @@
+const std = @import("std");
+const net = std.net;
+const print = std.debug.print;
+
+pub fn main() !void {
+    var args = std.process.args();
+    // The First (0 index) Argument is the path to the program.
+    _ = args.skip();
+    const port_value = args.next() orelse {
+        print("expect port as command line argument\n", .{});
+        std.os.exit(1);
+    };
+    const port = try std.fmt.parseInt(u16, port_value, 10);
+
+    const peer = try net.Address.parseIp4("127.0.0.1", port);
+    // Connect to peer
+    const stream = try net.tcpConnectToAddress(peer);
+    defer stream.close();
+    print("Connecting to {}\n", .{peer});
+
+    // Sending data to peer
+    const data = "hello zig";
+    var writer = stream.writer();
+    const size = try writer.write(data);
+    print("Sending '{s}' to peer, total written: {d} bytes\n", .{ data, size });
+    // Or just using `stream.writeAll`
+    // try stream.writeAll("hello zig");
+}


### PR DESCRIPTION
This PR adds an example of a TCP client, allowing us to connect to the server from section [04-01 ](https://zigcc.github.io/zig-cookbook/04-01-tcp-server.html) without using the `nc` command.