### PR TITLE
Clean up example 1.1

### DIFF
--- a/book-src/01-01-read-file-line-by-line.md
+++ b/book-src/01-01-read-file-line-by-line.md
@@ -8,33 +8,30 @@ const fs = std.fs;
 const print = std.debug.print;
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa: std.heap.GeneralPurposeAllocator(.{}) = .{};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
     const file = try fs.cwd().openFile("tests/zig-zen.txt", .{});
     defer file.close();
 
-    var rdr = blk: {
-        // Usually buffered reader is faster, so we use one here.
-        var buf_reader = std.io.bufferedReader(file.reader());
-        break :blk buf_reader.reader();
-    };
-    var line_no: usize = 0;
+    // Wrap the files reader in a buffered reader.
+    var buf_reader = std.io.bufferedReader(file.reader());
+    const reader = buf_reader.reader();
 
     var line = std.ArrayList(u8).init(allocator);
     defer line.deinit();
-    var wtr = line.writer();
-    while (true) {
-        // Clear the line so we can reuse it.
-        defer line.clearRetainingCapacity();
+    const writer = line.writer();
 
-        rdr.streamUntilDelimiter(wtr, '\n', 4096) catch |err| switch (err) {
-            error.EndOfStream => return,
-            else => return err,
-        };
-        line_no += 1;
+    var line_no: usize = 1;
+    while (reader.streamUntilDelimiter(writer, '\n', null)) : (line_no += 1) {
         print("{d}--{s}\n", .{ line_no, line.items });
+
+        // Clear the line so we can reuse it.
+        line.clearRetainingCapacity();
+    } else |err| switch (err) {
+        error.EndOfStream => {}, // Continue on
+        else => |e| return e, // Propagate error
     }
 }
 ```

--- a/book-src/01-01-read-file-line-by-line.md
+++ b/book-src/01-01-read-file-line-by-line.md
@@ -8,32 +8,34 @@ const fs = std.fs;
 const print = std.debug.print;
 
 pub fn main() !void {
-    var gpa: std.heap.GeneralPurposeAllocator(.{}) = .{};
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
     const file = try fs.cwd().openFile("tests/zig-zen.txt", .{});
     defer file.close();
 
-    // Wrap the files reader in a buffered reader.
+    // Wrap the file reader in a buffered reader.
+    // Since it's usually faster to read a bunch of bytes at once.
     var buf_reader = std.io.bufferedReader(file.reader());
     const reader = buf_reader.reader();
 
     var line = std.ArrayList(u8).init(allocator);
     defer line.deinit();
-    const writer = line.writer();
 
+    const writer = line.writer();
     var line_no: usize = 1;
     while (reader.streamUntilDelimiter(writer, '\n', null)) : (line_no += 1) {
-        print("{d}--{s}\n", .{ line_no, line.items });
-
         // Clear the line so we can reuse it.
-        line.clearRetainingCapacity();
+        defer line.clearRetainingCapacity();
+
+        print("{d}--{s}\n", .{ line_no, line.items });
     } else |err| switch (err) {
         error.EndOfStream => {}, // Continue on
         else => |e| return e, // Propagate error
     }
 }
+
 ```
 
 [Reader]: https://ziglang.org/documentation/0.11.0/std/#A;std:io.Reader

--- a/src/01-01.zig
+++ b/src/01-01.zig
@@ -3,27 +3,28 @@ const fs = std.fs;
 const print = std.debug.print;
 
 pub fn main() !void {
-    var gpa: std.heap.GeneralPurposeAllocator(.{}) = .{};
+    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
     const file = try fs.cwd().openFile("tests/zig-zen.txt", .{});
     defer file.close();
 
-    // Wrap the files reader in a buffered reader.
+    // Wrap the file reader in a buffered reader.
+    // Since it's usually faster to read a bunch of bytes at once.
     var buf_reader = std.io.bufferedReader(file.reader());
     const reader = buf_reader.reader();
 
     var line = std.ArrayList(u8).init(allocator);
     defer line.deinit();
-    const writer = line.writer();
 
+    const writer = line.writer();
     var line_no: usize = 1;
     while (reader.streamUntilDelimiter(writer, '\n', null)) : (line_no += 1) {
-        print("{d}--{s}\n", .{ line_no, line.items });
-
         // Clear the line so we can reuse it.
-        line.clearRetainingCapacity();
+        defer line.clearRetainingCapacity();
+
+        print("{d}--{s}\n", .{ line_no, line.items });
     } else |err| switch (err) {
         error.EndOfStream => {}, // Continue on
         else => |e| return e, // Propagate error

--- a/src/01-01.zig
+++ b/src/01-01.zig
@@ -3,32 +3,29 @@ const fs = std.fs;
 const print = std.debug.print;
 
 pub fn main() !void {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa: std.heap.GeneralPurposeAllocator(.{}) = .{};
     defer _ = gpa.deinit();
     const allocator = gpa.allocator();
 
     const file = try fs.cwd().openFile("tests/zig-zen.txt", .{});
     defer file.close();
 
-    var rdr = blk: {
-        // Usually buffered reader is faster, so we use one here.
-        var buf_reader = std.io.bufferedReader(file.reader());
-        break :blk buf_reader.reader();
-    };
-    var line_no: usize = 0;
+    // Wrap the files reader in a buffered reader.
+    var buf_reader = std.io.bufferedReader(file.reader());
+    const reader = buf_reader.reader();
 
     var line = std.ArrayList(u8).init(allocator);
     defer line.deinit();
-    var wtr = line.writer();
-    while (true) {
-        // Clear the line so we can reuse it.
-        defer line.clearRetainingCapacity();
+    const writer = line.writer();
 
-        rdr.streamUntilDelimiter(wtr, '\n', 4096) catch |err| switch (err) {
-            error.EndOfStream => return,
-            else => return err,
-        };
-        line_no += 1;
+    var line_no: usize = 1;
+    while (reader.streamUntilDelimiter(writer, '\n', null)) : (line_no += 1) {
         print("{d}--{s}\n", .{ line_no, line.items });
+
+        // Clear the line so we can reuse it.
+        line.clearRetainingCapacity();
+    } else |err| switch (err) {
+        error.EndOfStream => {}, // Continue on
+        else => |e| return e, // Propagate error
     }
 }


### PR DESCRIPTION
The example creates a reader like so:
```zig
    var rdr = blk: {
        // Usually buffered reader is faster, so we use one here.
        var buf_reader = std.io.bufferedReader(file.reader());
        break :blk buf_reader.reader();
    };
```
The `Reader` for a `BufferedReader` stores a pointer to the `BufferedReader`. So when this block is exited, the `BufferedReader` goes out of scope and the `Reader` returned from the block holds a pointer to that (now invalid) memory.
While the current implementation may coincidentally 'work', it invokes undefined behaviour.
The solution is to leave the `BufferedReader` instance in scope for as long as it's `Reader` is being used.

1.1 also does not compile on Zig master due to a `local variable is never mutated` error, and that is fixed by making both the reader and writer `const`.

This PR also moves the `steamUntilDelimiter` call to the condition part of the `while` loop instead of using `while (true)`, and also uses error set narrowing on the error switch.