### PR TITLE
fix: stream.writer() 04-02.zig

### DIFF
--- a/src/04-02.zig
+++ b/src/04-02.zig
@@ -23,6 +23,6 @@ pub fn main() !void {
     var writer = stream.writer();
     const size = try writer.write(data);
     print("Sending '{s}' to peer, total written: {d} bytes\n", .{ data, size });
-    // Or just using `stream.writeAll`
-    // try stream.writer().writeAll("hello zig");
+    // Or just using `writer.writeAll`
+    // try writer.writeAll("hello zig");
 }

--- a/src/04-02.zig
+++ b/src/04-02.zig
@@ -24,5 +24,5 @@ pub fn main() !void {
     const size = try writer.write(data);
     print("Sending '{s}' to peer, total written: {d} bytes\n", .{ data, size });
     // Or just using `stream.writeAll`
-    // try stream.writeAll("hello zig");
+    // try stream.writer().writeAll("hello zig");
 }


### PR DESCRIPTION
stream.writeAll("hello zig") won't work without writer in case we use reader() in server 04-01.zig.