### PR TITLE
Update 01-01.zig to be able to read the last line of the file

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,0 @@
-# zig 0.11.0
-zig master

--- a/src/01-01.zig
+++ b/src/01-01.zig
@@ -19,16 +19,22 @@ pub fn main() !void {
     defer line.deinit();
 
     const writer = line.writer();
-    var line_no: usize = 1;
-    var eof = false;
-    while (!eof) : (line_no += 1) {
-        reader.streamUntilDelimiter(writer, '\n', null) catch |err| switch (err) {
-            error.EndOfStream => eof = true, // One last pass before we exit the while loop
-            else => return err, // Propagate error
-        };
+    var line_no: usize = 0;
+    while (reader.streamUntilDelimiter(writer, '\n', null)) {
         // Clear the line so we can reuse it.
         defer line.clearRetainingCapacity();
+        line_no += 1;
 
         print("{d}--{s}\n", .{ line_no, line.items });
+    } else |err| switch (err) {
+        error.EndOfStream => { // end of file
+            if (line.items.len > 0) {
+                line_no += 1;
+                print("{d}--{s}\n", .{ line_no, line.items });
+            }
+        },
+        else => return err, // Propagate error
     }
+
+    print("Total lines: {d}\n", .{line_no});
 }

--- a/src/01-01.zig
+++ b/src/01-01.zig
@@ -20,13 +20,15 @@ pub fn main() !void {
 
     const writer = line.writer();
     var line_no: usize = 1;
-    while (reader.streamUntilDelimiter(writer, '\n', null)) : (line_no += 1) {
+    var eof = false;
+    while (!eof) : (line_no += 1) {
+        reader.streamUntilDelimiter(writer, '\n', null) catch |err| switch (err) {
+            error.EndOfStream => eof = true, // One last pass before we exit the while loop
+            else => return err, // Propagate error
+        };
         // Clear the line so we can reuse it.
         defer line.clearRetainingCapacity();
 
         print("{d}--{s}\n", .{ line_no, line.items });
-    } else |err| switch (err) {
-        error.EndOfStream => {}, // Continue on
-        else => return err, // Propagate error
     }
 }


### PR DESCRIPTION
Current 01-01 ([Read file line by line](https://cookbook.ziglang.cc/01-01-read-file-line-by-line.html#read-file-line-by-line)) misses the last line of the file.

This (kinda clumsy) version fixes that by flagging `error.EndOfStream` and using the flag as the `while` condition. Any suggestions on how to tidy this up are appreciated.