### PR TITLE
update book-src/15-01-regex.md: cured repo of RAS syndrome

### DIFF
--- a/book-src/15-01-regex.md
+++ b/book-src/15-01-regex.md
@@ -1,4 +1,4 @@
-# Regex Expressions
+# Regular Expressions
 
 Currently there is no regex support in Zig, so the best way to go is binding with Posix's [regex.h](https://pubs.opengroup.org/onlinepubs/7908799/xsh/regex.h.html).
 


### PR DESCRIPTION
"Regex Expressions" is a redundant term, as regex is short for "Regular Expressions", I've made a single line commit to change this.