### PR TITLE
chore: use `pkgconf` rather than `pkg-config` for brew builds

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,7 @@ run:
 install-deps:
 ifeq ($(uname_S), Darwin)
 	# sqlite3 is preinstalled on macOS
-	brew install pkg-config libpq mysql-client
+	brew install pkgconf libpq mysql-client
 endif
 ifeq ($(uname_S), Linux)
 	sudo apt install -y pkg-config libsqlite3-dev libpq-dev libmysqlclient-dev


### PR DESCRIPTION
right now, pkgconf is an alias for pkg-config, but it would be better to be explicit about it.

relates to https://github.com/Homebrew/brew/pull/18843