### PR TITLE
fix(crypto): correct recipe docs and examples

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,3 @@
 # https://github.com/github-linguist/linguist/blob/master/docs/overrides.md#documentation
 examples/* -linguist-documentation
+tests/zig-zen.txt text eol=lf

--- a/assets/src/02-03.zig
+++ b/assets/src/02-03.zig
@@ -15,7 +15,7 @@ pub fn main(init: std.process.Init) !void {
     //Parameters for Argon2id
     const params = std.crypto.pwhash.argon2.Params{
         .t = 3, // Iterations (time cost)
-        .m = 16, // Memory cost in KiB (here 16 MiB)
+        .m = 16 * 1024, // Memory cost in KiB (here 16 MiB)
         .p = 1, // Threads
     };
 

--- a/assets/src/02-03.zig
+++ b/assets/src/02-03.zig
@@ -15,7 +15,7 @@ pub fn main(init: std.process.Init) !void {
     //Parameters for Argon2id
     const params = std.crypto.pwhash.argon2.Params{
         .t = 3, // Iterations (time cost)
-        .m = 16 * 1024, // Memory cost in KiB (here 16 MiB)
+        .m = 16, // Memory cost in KiB (here 16 KiB)
         .p = 1, // Threads
     };
 

--- a/src/en-US/02-01-sha-digest.smd
+++ b/src/en-US/02-01-sha-digest.smd
@@ -4,7 +4,6 @@
 .author = "ZigCC",
 .layout = "section.shtml",
 ---
-Calculate SHA-256 digest of a file
 
 There are many crypto algorithm implementations in std, `sha256`, `md5` are supported out of box.
 

--- a/src/en-US/02-02-pbkdf2.smd
+++ b/src/en-US/02-02-pbkdf2.smd
@@ -4,7 +4,6 @@
 .author = "ZigCC",
 .layout = "section.shtml",
 ---
-Salt and hash a password with PBKDF2
 
 Uses [`std.crypto.pwhash.pbkdf2`] to hash a salted password using HMAC-SHA256. In production, the salt should be generated randomly using [`std.Io.randomSecure`].
 

--- a/src/en-US/02-03-argon2.smd
+++ b/src/en-US/02-03-argon2.smd
@@ -4,9 +4,8 @@
 .author = "ZigCC",
 .layout = "section.shtml",
 ---
-Salt and hash a password with Argon2
 
-This Zig program derives a cryptographic key from a password and salt using the Argon2id password hashing algorithm. It uses [std.crypto.pwhash.argon2] to hash a salted password, where the salt is generated using [`std.Io.randomSecure`].
+This Zig program derives a cryptographic key from a password and salt using the Argon2id password hashing algorithm. It uses [`std.crypto.pwhash.argon2`] to hash a salted password, where the salt is generated using [`std.Io.randomSecure`].
 
 []($code.siteAsset('src/02-03.zig').language('zig'))
 

--- a/src/zh-CN/02-01-sha-digest.smd
+++ b/src/zh-CN/02-01-sha-digest.smd
@@ -4,7 +4,6 @@
 .author = "ZigCC",
 .layout = "section.shtml",
 ---
-计算文件的 SHA-256 摘要
 
 标准库中实现了许多加密算法，`sha256` 和 `md5` 都是开箱即用的。
 

--- a/src/zh-CN/02-02-pbkdf2.smd
+++ b/src/zh-CN/02-02-pbkdf2.smd
@@ -4,7 +4,6 @@
 .author = "ZigCC",
 .layout = "section.shtml",
 ---
-使用 PBKDF2 对密码进行加盐和哈希
 
 使用 [`std.crypto.pwhash.pbkdf2`] 通过 HMAC-SHA256 对加盐后的密码进行哈希处理。在生产环境中，盐值应使用 [`std.Io.randomSecure`] 随机生成。
 

--- a/src/zh-CN/02-03-argon2.smd
+++ b/src/zh-CN/02-03-argon2.smd
@@ -4,9 +4,8 @@
 .author = "ZigCC",
 .layout = "section.shtml",
 ---
-使用 Argon2 对密码进行加盐和哈希
 
-此 Zig 程序使用 Argon2id 密码哈希算法从密码和盐值派生加密密钥。它使用 [std.crypto.pwhash.argon2] 对加盐后的密码进行哈希处理，其中盐值是使用 [`std.Io.randomSecure`] 生成的。
+此 Zig 程序使用 Argon2id 密码哈希算法从密码和盐值派生加密密钥。它使用 [`std.crypto.pwhash.argon2`] 对加盐后的密码进行哈希处理，其中盐值是使用 [`std.Io.randomSecure`] 生成的。
 
 []($code.siteAsset('src/02-03.zig').language('zig'))
 


### PR DESCRIPTION
- remove duplicated recipe titles from the English and Chinese pages
- fix the Argon2 API reference link
  
  <img width="916" height="302" alt="image" src="https://github.com/user-attachments/assets/7c68717b-f8be-4373-963a-c62c1ef1883d" />

- correct the Argon2 memory cost from 16 KiB to 16 MiB
- enforce LF line endings for the SHA-256 test fixture so its digest is consistent across platforms


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Corrected the Argon2id example’s memory-cost description to accurately state 16 KiB.
  - Removed redundant headings from SHA-256, PBKDF2, and Argon2 examples in English and Chinese documentation.
  - Improved Argon2 explanations and formatted references consistently.
  - Standardized text classification and line endings for a test resource.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->